### PR TITLE
Use degit instead of git clone in setup example

### DIFF
--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -22,7 +22,7 @@ We highly recommend to use [VSCode](https://code.visualstudio.com/) with the fol
 <br />
 
 ```
-git clone https://github.com/kefranabg/bento-starter.git
+npx degit kefranabg/bento-starter
 cd bento-starter
 cp .env.example .env.local
 npm i


### PR DESCRIPTION
`git clone` also pulls in all of the scaffold's git history, which is
a) unnecessary for a fresh project
b) slower

The [`degit`](https://github.com/Rich-Harris/degit) package allows you to clone a git repo without its history. It's meant for scaffolding projects like `bento` :)

And I thought using `npx` is better than asking a user to install it globally.


PS! Love the project 👍 